### PR TITLE
Push to ECR instead of JFrog

### DIFF
--- a/buildScripts/jenkins/dsl/pull_request.groovy
+++ b/buildScripts/jenkins/dsl/pull_request.groovy
@@ -62,7 +62,7 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t kenshoo-docker.jfrog.io/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base -f Dockerfile-ciab . && echo "Successfully built base image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/pull_request.groovy
+++ b/buildScripts/jenkins/dsl/pull_request.groovy
@@ -62,7 +62,7 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:TEMP-FOR-TESTING76 -f Dockerfile-ciab . && echo "Successfully built base image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/release.groovy
+++ b/buildScripts/jenkins/dsl/release.groovy
@@ -56,8 +56,8 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base -f Dockerfile-ciab . && echo "Successfully built base image"
-          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base && echo "Successfully pushed image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:TEMP-FOR-TESTING76 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:TEMP-FOR-TESTING76 && echo "Successfully pushed image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/release.groovy
+++ b/buildScripts/jenkins/dsl/release.groovy
@@ -56,8 +56,8 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t kenshoo-docker.jfrog.io/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base -f Dockerfile-ciab . && echo "Successfully built base image"
-          docker push kenshoo-docker.jfrog.io/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base && echo "Successfully pushed image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/TEMP-FOR-TESTING-ks-db-memsql-76-cluster-in-a-box-base && echo "Successfully pushed image"
       """)
     }
 


### PR DESCRIPTION
Change artifactory from JFrog to to ECR, to align with Skai best practices, and to gain "free" artifactory credentials from Jenkins nodes without having to modify the repo further.