### PR TITLE
Generate 7.8.11 base image for Mac M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SERVER_VERSION=7.6.13-39da2f5c72# CHANGED FROM SOURCE: enforce the specific version that we need for Skai's use-case
+SERVER_VERSION=7.8.11-f27d515772# CHANGED FROM SOURCE: enforce the specific version that we need for Skai's use-case
 SERVER_VERSION_PREVIEW=7.9.4-1a8fd43c84
 SERVER_VERSION_6_8=6.8.24-8e110b7bed
 SERVER_VERSION_7_0=7.0.26-8999f1390b

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Introduction & motivation 
-This repo is a clone of [memsql/deployment-docker](https://github.com/memsql/deployment-docker), customized for building the Skai KS base MemSQL image that is used for [building the automation image](https://jenkins-prod-search.internalk.com/job/automation-tests-db-upload/) for our local environments and testing environments on Jenkins. This process is comprised of (as of Dec 2022):
+This repo is a fork of [memsql/deployment-docker](https://github.com/memsql/deployment-docker), customized for building the Skai KS base MemSQL image that is used for [building the automation image](https://jenkins-prod-search.internalk.com/job/automation-tests-db-upload/) for our local environments and testing environments on Jenkins. This process is comprised of (as of Dec 2022):
 1. Starting a cluster-in-a-box memsql docker image.
 2. Running several cucumbers to populate it with schemas, tables and data.
 3. Committing the docker state and upload the image to an artifactory.
@@ -25,8 +25,8 @@ The main changes made to the repo are:
 
 # Building the base image
 
-This section will be updated once we have created a jenkins job to do it for us.
-For now, see instructions on how to create the image locally and pushing it to the artifactory in PR https://github.com/kenshoo/memsql-base-automation-image-builder/pull/1.
+Run the release job: https://jenkins-prod-microcosm.internalk.com/job/memsql-base-automation-image-builder-release.
+If you've made changes to the DSL files, you will need to run https://jenkins-prod-microcosm.internalk.com/job/memsql-base-automation-image-builder-main-dsl/ first.
   
 # Recommendations - discovery for next version upgrade
 

--- a/buildScripts/jenkins/dsl/pull_request.groovy
+++ b/buildScripts/jenkins/dsl/pull_request.groovy
@@ -62,7 +62,7 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:TEMP-FOR-TESTING76 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:v7-8-11 -f Dockerfile-ciab . && echo "Successfully built base image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/pull_request.groovy
+++ b/buildScripts/jenkins/dsl/pull_request.groovy
@@ -62,7 +62,7 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:v7-8-11 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.8.11 -f Dockerfile-ciab . && echo "Successfully built base image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/release.groovy
+++ b/buildScripts/jenkins/dsl/release.groovy
@@ -56,8 +56,8 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:TEMP-FOR-TESTING76 -f Dockerfile-ciab . && echo "Successfully built base image"
-          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:TEMP-FOR-TESTING76 && echo "Successfully pushed image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:v7-8-11 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:v7-8-11 && echo "Successfully pushed image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/release.groovy
+++ b/buildScripts/jenkins/dsl/release.groovy
@@ -56,8 +56,8 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:v7-8-11 -f Dockerfile-ciab . && echo "Successfully built base image"
-          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:v7-8-11 && echo "Successfully pushed image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.8.11 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.8.11 && echo "Successfully pushed image"
       """)
     }
 


### PR DESCRIPTION
We want to support using MemSQL dockers on Mac M1 computers. MemSQL started supporting M1 in version 7.8.11 (see [forum thread](https://www.singlestore.com/forum/t/singlestore-for-arm64-m1-macs/2877/22)).

This PR temporarily changes version number + docker tags to specify MemSQL version 7.8.11. We will run the automation to create a base image, and then the next PR will revert back to 7.6, which is the production version used in Skai.

The exact version number is taken from this [commit from the source repo](https://github.com/memsql/deployment-docker/commit/2fe16c23c073d0dfaed35e59b191c2475872d4d3), which is NOT included in the current version of this fork.