### PR TITLE
Update missing parameter for generating a 7.8.11 base image

### DIFF
--- a/Dockerfile-ciab
+++ b/Dockerfile-ciab
@@ -8,7 +8,7 @@ FROM ${BASE_IMAGE}
 # CHANGED FROM SOURCE: switch to root, add specific versions according to Makefile
 USER root
 ARG CLIENT_VERSION="1.0.5"
-ARG SERVER_VERSION="7.6.13-39da2f5c72"
+ARG SERVER_VERSION="7.8.11-f27d515772"
 ARG STUDIO_VERSION="4.0.7"
 ARG TOOLBOX_VERSION="1.13.9"
 RUN yum install -y \


### PR DESCRIPTION
Add missing parameter from #6.

Reminder for the context:
>We want to support using MemSQL dockers on Mac M1 computers. MemSQL started supporting M1 in version 7.8.11 (see [forum thread](https://www.singlestore.com/forum/t/singlestore-for-arm64-m1-macs/2877/22)).<br>
This PR temporarily changes version number + docker tags to specify MemSQL version 7.8.11. We will run the automation to create a base image, and then the next PR will revert back to 7.6, which is the production version used in Skai.<br>
The exact version number is taken from this [commit from the source repo](https://github.com/memsql/deployment-docker/commit/2fe16c23c073d0dfaed35e59b191c2475872d4d3), which is NOT included in the current version of this fork.