### PR TITLE
Restore image version to 7.6.13

### DIFF
--- a/Dockerfile-ciab
+++ b/Dockerfile-ciab
@@ -8,7 +8,7 @@ FROM ${BASE_IMAGE}
 # CHANGED FROM SOURCE: switch to root, add specific versions according to Makefile
 USER root
 ARG CLIENT_VERSION="1.0.5"
-ARG SERVER_VERSION="7.8.11-f27d515772"
+ARG SERVER_VERSION="7.6.13-39da2f5c72"
 ARG STUDIO_VERSION="4.0.7"
 ARG TOOLBOX_VERSION="1.13.9"
 RUN yum install -y \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SERVER_VERSION=7.8.11-f27d515772# CHANGED FROM SOURCE: enforce the specific version that we need for Skai's use-case
+SERVER_VERSION=7.6.13-39da2f5c72# CHANGED FROM SOURCE: enforce the specific version that we need for Skai's use-case
 SERVER_VERSION_PREVIEW=7.9.4-1a8fd43c84
 SERVER_VERSION_6_8=6.8.24-8e110b7bed
 SERVER_VERSION_7_0=7.0.26-8999f1390b

--- a/buildScripts/jenkins/dsl/pull_request.groovy
+++ b/buildScripts/jenkins/dsl/pull_request.groovy
@@ -62,7 +62,7 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.8.11 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.6.13 -f Dockerfile-ciab . && echo "Successfully built base image"
       """)
     }
 

--- a/buildScripts/jenkins/dsl/release.groovy
+++ b/buildScripts/jenkins/dsl/release.groovy
@@ -56,8 +56,8 @@ job(JOB_NAME) {
     steps {
         shell("""
           make
-          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.8.11 -f Dockerfile-ciab . && echo "Successfully built base image"
-          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.8.11 && echo "Successfully pushed image"
+          docker build -t 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.6.13 -f Dockerfile-ciab . && echo "Successfully built base image"
+          docker push 668139184987.dkr.ecr.us-east-1.amazonaws.com/ks-db-memsql-cluster-in-a-box-base:7.6.13 && echo "Successfully pushed image"
       """)
     }
 


### PR DESCRIPTION
After having temporarily updated the image version to 7.8.11 to do a one-time build of a base image for Mac M1 users, this PR changes the version back to 7.6.13, to align with the production version.