### PR TITLE
Change job recipients to testing-infra

### DIFF
--- a/buildScripts/jenkins/dsl/pull_request.groovy
+++ b/buildScripts/jenkins/dsl/pull_request.groovy
@@ -1,5 +1,5 @@
 def NAME = "memsql-base-automation-image-builder"
-def EMAIL = "_devmicrocosm@kenshoo.com"
+def EMAIL = "shmulik.gutman@skai.io,shaked.nahum@skai.io"
 def JOB_NAME = "${NAME}-pull-request"
 
 job(JOB_NAME) {

--- a/buildScripts/jenkins/dsl/release.groovy
+++ b/buildScripts/jenkins/dsl/release.groovy
@@ -1,5 +1,5 @@
 def NAME = "memsql-base-automation-image-builder"
-def EMAIL = "_devmicrocosm@kenshoo.com"
+def EMAIL = "shmulik.gutman@skai.io,shaked.nahum@skai.io"
 def JOB_NAME = "${NAME}-release"
 def BRANCH_NAME = "master"
 


### PR DESCRIPTION
After finalizing development of this automation repo, moving its Jenkins jobs recipient to be testing-infra team.