### PR TITLE
set data_conversion_compatibility_level=6.0 global var

### DIFF
--- a/ciab-assets/startup
+++ b/ciab-assets/startup
@@ -65,6 +65,9 @@ else #initialize the cluster
    memsqlctl -y update-config --all --set-global --key LOG_FILE_SIZE_PARTITIONS --value 268435456
    memsqlctl -y update-config --all --set-global --key LOG_FILE_SIZE_REF_DBS --value 67108864
 
+# CHANGED FROM SOURCE: added configuration to prevent data errors.
+   memsqlctl -y update-config --all --set-global --key data_conversion_compatibility_level --value 6.0 
+
 # CHANGED FROM SOURCE: unregistered the host, because it prevents raising the docker twice. 
    sdb-toolbox-config unregister-host -y --host 127.0.0.1
    echo Done.


### PR DESCRIPTION
DATA-00000
`data_conversion_compatibility_level` value was updated to `8.0` by default in Singlestore 8 onwards.
This caused "`Invalid DATE/TIME in type conversion`" errors on SEARCH when copying data to the memsql docker.

In order to avoid that we set the  `data_conversion_compatibility_level` value back to `6.0`